### PR TITLE
Update README: concise repository structure overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,42 +300,14 @@ dotnet ef database update \
 
 ```
 MeridianConsole/
-  Dhadgar.sln
-  src/
-    Shared/
-      Dhadgar.Shared
-      Dhadgar.Contracts
-      Dhadgar.Messaging
-      Dhadgar.ServiceDefaults
-    Agents/
-      Dhadgar.Agent.Core
-      Dhadgar.Agent.Linux
-      Dhadgar.Agent.Windows
-    Dhadgar.Gateway
-    Dhadgar.Identity
-    Dhadgar.Billing
-    Dhadgar.Servers
-    Dhadgar.Nodes
-    Dhadgar.Tasks
-    Dhadgar.Files
-    Dhadgar.Console
-    Dhadgar.Mods
-    Dhadgar.Notifications
-    Dhadgar.Firewall
-    Dhadgar.Secrets
-    Dhadgar.Discord
-    Dhadgar.Web
-    Dhadgar.Scope
-    Dhadgar.Cli
-  tests/
-    <One test project per project>
-  deploy/
-    compose/
-      docker-compose.dev.yml
-  docs/
-    architecture/
-    runbooks/
-    kip/
+  Dhadgar.sln        # Main .NET solution entry point.
+  global.json        # SDK pinning and toolchain versioning.
+  src/               # Core application code and shared libraries.
+    Shared/          # Cross-cutting contracts, messaging, and defaults.
+    Agents/          # Agent implementations and platform-specific runtimes.
+  tests/             # Automated tests organized by feature area.
+  deploy/            # Deployment templates and infrastructure scaffolding.
+  docs/              # Public-facing documentation and architectural overviews.
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- Make the README "Local repository structure" section concise and suitable for public readers.
- Replace a verbose per-service listing with a high-level layout focused on top-level folders like `src`, `tests`, `deploy`, and `docs` and key root files such as `Dhadgar.sln` and `global.json`.
- Preserve high-level references to `Shared` and `Agents` without enumerating every service or internal project.
- Ensure each entry has a brief, non-internal description (≤25 words).

### Description
- Replaced the expanded tree under "Local repository structure" with a compact block listing `Dhadgar.sln`, `global.json`, `src/`, `tests/`, `deploy/`, and `docs/`.
- Added short public-facing descriptions for each top-level entry within the same code block.
- Kept `src/Shared/` and `src/Agents/` as high-level sub-areas and removed per-service listings.
- Removed internal or operational details from the repository layout section.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da36a2b64832b8dbb2a30197884fc)