### PR TITLE
docs(helm): add non-functional status banner to chart README

### DIFF
--- a/deploy/kubernetes/helm/meridian-console/README.md
+++ b/deploy/kubernetes/helm/meridian-console/README.md
@@ -1,5 +1,7 @@
 # Meridian Console Helm Chart
 
+> **Status: non-functional** — see issue [#135](https://github.com/SandboxServers/MeridianConsole/issues/135); Kubernetes is post-beta, `deploy/compose` is the beta deployment story.
+
 A Helm chart for deploying Meridian Console - a modern, security-first game server control plane.
 
 ## Overview


### PR DESCRIPTION
Part of #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGdu91QcJ9qCxa1a2qz6gb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a status notice clarifying that the Meridian Console Helm chart is currently non-functional.
  * Directed users to the Compose deployment option as the supported beta deployment path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->