### PR TITLE
chore(deps): bump better-auth to >=1.6.13 - clears critical GHSA-pw9m-5jxm-xr6h (P0.6)

### DIFF
--- a/src/Dhadgar.BetterAuth/package-lock.json
+++ b/src/Dhadgar.BetterAuth/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dhadgar-betterauth",
       "version": "0.1.0",
       "dependencies": {
-        "better-auth": "^1.3.1",
+        "better-auth": "^1.6.25",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -17,17 +17,19 @@
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "peer": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "2.1.1",
@@ -51,6 +53,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -79,32 +90,38 @@
       "license": "MIT"
     },
     "node_modules/better-auth": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.10.tgz",
-      "integrity": "sha512-0kqwEBJLe8eyFzbUspRG/htOriCf9uMLlnpe34dlIJGdmDfPuQISd4shShvUrvIVhPxsY1dSTXdXPLpqISYOYg==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
+      "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.10",
-        "@better-auth/telemetry": "1.4.10",
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.0.0",
-        "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.7",
+        "@better-auth/core": "1.6.25",
+        "@better-auth/drizzle-adapter": "1.6.25",
+        "@better-auth/kysely-adapter": "1.6.25",
+        "@better-auth/memory-adapter": "1.6.25",
+        "@better-auth/mongo-adapter": "1.6.25",
+        "@better-auth/prisma-adapter": "1.6.25",
+        "@better-auth/telemetry": "1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1",
-        "zod": "^4.1.12"
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17 || ^0.29.0",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@lynx-js/react": "*",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -128,6 +145,9 @@
           "optional": true
         },
         "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
           "optional": true
         },
         "better-sqlite3": {
@@ -175,56 +195,142 @@
       }
     },
     "node_modules/better-auth/node_modules/@better-auth/core": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.10.tgz",
-      "integrity": "sha512-AThrfb6CpG80wqkanfrbN2/fGOYzhGladHFf3JhaWt/3/Vtf4h084T6PJLrDE7M/vCCGYvDI1DkvP3P1OB2HAg==",
-      "peer": true,
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
+      "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
+      "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "zod": "^4.1.12"
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.7",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
+      "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
+      "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
+      "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2"
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
+      "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
+      "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/better-auth/node_modules/@better-auth/telemetry": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.10.tgz",
-      "integrity": "sha512-Dq4XJX6EKsUu0h3jpRagX739p/VMOTcnJYWRrLtDYkqtZFg+sFiFsSWVcfapZoWpRSUGYX9iKwl6nDHn6Ju2oQ==",
-      "dependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21"
-      },
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
+      "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
+      "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.4.10"
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
       }
     },
     "node_modules/better-auth/node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/better-call": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
-      "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@better-auth/utils": "^0.3.0",
-        "@better-fetch/fetch": "^1.1.4",
-        "rou3": "^0.7.10",
-        "set-cookie-parser": "^2.7.1"
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -236,9 +342,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -249,7 +355,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -356,9 +462,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -440,9 +546,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -467,14 +573,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -493,7 +599,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -619,9 +725,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -687,13 +793,12 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
-      "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.4.tgz",
+      "integrity": "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -772,9 +877,9 @@
       "license": "MIT"
     },
     "node_modules/nanostores": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.0.tgz",
-      "integrity": "sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.1.tgz",
+      "integrity": "sha512-PGd3uPojJB9Z07d5NX3Db/SOSBbyy3wLMUGq0GpnEEJfVzY9mq7daPMAZ3jObV5D3Jn+YKND636eI5ULg7F80Q==",
       "funding": [
         {
           "type": "github",
@@ -782,7 +887,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -839,9 +943,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -849,7 +953,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -987,12 +1090,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1103,9 +1207,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -1115,14 +1219,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1134,13 +1238,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1263,9 +1367,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/Dhadgar.BetterAuth/package.json
+++ b/src/Dhadgar.BetterAuth/package.json
@@ -8,7 +8,7 @@
     "start": "node src/server.js"
   },
   "dependencies": {
-    "better-auth": "^1.3.1",
+    "better-auth": "^1.6.25",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/src/Dhadgar.BetterAuth/src/server.js
+++ b/src/Dhadgar.BetterAuth/src/server.js
@@ -3,7 +3,8 @@ import express from "express";
 import cors from "cors";
 import pg from "pg";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
-import { getMigrations } from "better-auth/db";
+// better-auth >= 1.6 moved getMigrations from "better-auth/db" to "better-auth/db/migration"
+import { getMigrations } from "better-auth/db/migration";
 import { loadSecrets } from "./secrets-client.js";
 
 // Load secrets from Secrets Service before initializing the app
@@ -38,7 +39,8 @@ async function runMigrations() {
       console.log(`  Tables to create: ${toBeCreated.map(t => t.table).join(", ")}`);
     }
     if (toBeAdded.length > 0) {
-      console.log(`  Fields to add: ${toBeAdded.map(t => `${t.table}.${t.fields?.join(", ")}`).join("; ")}`);
+      // t.fields is a Record<string, FieldAttribute>, not an array
+      console.log(`  Fields to add: ${toBeAdded.map(t => `${t.table}.${Object.keys(t.fields ?? {}).join(", ")}`).join("; ")}`);
     }
 
     await runMigrations();


### PR DESCRIPTION
## Summary

P0.6 of #129: clears the repo's only **critical** Dependabot alert (alert 146, OAuth refresh-token replay, GHSA-pw9m-5jxm-xr6h) and all high alerts on the `src/Dhadgar.BetterAuth/package-lock.json` manifest by bumping `better-auth` and refreshing the lock. `better-auth` was bumped to `^1.6.25` (latest stable) rather than the 1.6.13 minimum because npm audit flags `better-auth <= 1.6.21` — four additional advisories (including a second critical, GHSA-wxw3-q3m9-c3jr, which directly affects this app's `storeStateStrategy: "cookie"` config) are only patched in 1.6.22+.

## Resolved versions (before → after)

| Package | Before | After | Cleared advisories |
| --- | --- | --- | --- |
| better-auth (declared) | `^1.3.1` | `^1.6.25` | — |
| better-auth (resolved) | 1.4.10 | 1.6.25 | GHSA-pw9m-5jxm-xr6h (critical), GHSA-wxw3-q3m9-c3jr (critical), GHSA-86j7-9j95-vpqj (`javascript:` redirect XSS, fixed 1.6.13), GHSA-9h47-pqcx-hjr4 (oidcProvider crypto defaults), GHSA-g38m-r43w-p2q7, GHSA-392p-2q2v-4372, GHSA-7w99-5wm4-3g79, GHSA-qq9h-g4jm-xgf3, GHSA-fmh4-wcc4-5jm3, GHSA-2vg6-77g8-24mp, GHSA-p6v2-xcpg-h6xw |
| kysely | 0.28.9 | 0.29.4 | GHSA-wmrf-hv6w-mr66, GHSA-8cpq-38p9-67gx, GHSA-pv5w-4p9q-p3v2 (high) |
| path-to-regexp | 0.1.12 | 0.1.13 | GHSA-37ch-88jc-xwx2 (high) |
| defu | 6.1.4 | 6.1.7 | GHSA-737v-mqg7-c878 (high) |
| express | 4.22.1 | 4.22.2 | (qs transitive) |
| qs | 6.14.1 | 6.15.3 | GHSA-w7fw-mjwx-w883, GHSA-q8mj-m7cp-5q26 (moderate) |
| body-parser | 1.20.4 | 1.20.6 | GHSA-v422-hmwv-36x6 (moderate) |

No `overrides` block was needed — everything resolved transitively (`npm install` + `npm audit fix`, all within existing declared ranges; express stayed on 4.x).

`npm audit`: **before** 7 vulnerabilities (1 critical, 3 high, 3 moderate) → **after** 0 vulnerabilities.

Expected Dependabot closures on this manifest once the scan cycle runs: the critical (alert 146) + the 7 better-auth highs + kysely/path-to-regexp/defu transitive highs + qs/body-parser moderates.

## Code changes (breaking-change accommodations)

- `src/server.js`: `getMigrations` moved from `better-auth/db` to `better-auth/db/migration` (v1.5.0 breaking change). Import updated.
- `src/server.js`: fixed the migration log line — `toBeAdded[].fields` is a `Record`, not an array, so the old `fields?.join(", ")` threw inside the try block and would have **silently skipped `runMigrations()`** whenever columns needed adding. Now uses `Object.keys(...)`.

## 1.4 → 1.6 breaking-change review (notes for the #130 implementer)

- **Origin/CSRF hardening (behavior change, verified locally):** better-auth 1.6 rejects state-changing POSTs with `403 MISSING_OR_NULL_ORIGIN` when the request carries cookies or fetch-metadata (`Sec-Fetch-*`) headers but no `Origin`/`Referer` from `trustedOrigins`. Browsers always send `Origin` on POST, so real login flows are fine as long as the frontend origins stay in `BETTER_AUTH_TRUSTED_ORIGINS`. But **Node `fetch`/undici sends `sec-fetch-mode: cors`**, so any server-to-server POST to better-auth endpoints (scripts, health probes, service calls) now needs an explicit `Origin` header from the trusted list. New escape hatches exist: `advanced.disableCSRFCheck`, `account.skipStateCookieCheck`.
- **Cookie behavior otherwise unchanged (verified against installed source):** `advanced.crossSubDomainCookies` and `advanced.defaultCookieAttributes` have identical semantics in 1.6.25 (`node_modules/better-auth/dist/cookies/index.mjs`); a live check produced exactly the configured attributes: `Domain=meridianconsole.com; Path=/; HttpOnly; Secure; SameSite=None; Partitioned; Max-Age=604800`. The `__Secure-` cookie-name prefix logic is unchanged (driven by https `baseURL` / `useSecureCookies`) — relevant to #130's localhost-cookie work (DV-12): the hardcoded `meridianconsole.com` domain still comes from our config, not the library.
- **Session cookie cache:** `session.cookieCache { enabled, maxAge }` still valid; 1.6 adds a `strategy` option (default `"compact"`, base64url + HMAC-SHA256). The cache-cookie wire format changed vs 1.4, so existing cached-session cookies are invalidated once and silently refreshed from the DB — no forced re-login (the session token cookie and DB session are untouched).
- **`freshAge`** (1.6.0) is now computed from session creation time instead of update time. We don't set it and only call `getSession`, so no impact.
- **oidcProvider crypto defaults (GHSA-9h47-pqcx-hjr4):** patched upstream (no more `alg: none` advertisement / plain PKCE by default). This app does **not** use the `oidcProvider` or `mcp` plugins (only `genericOAuth` for Microsoft WIF), so the vuln was not directly reachable — cleared as a dependency hygiene matter. Note: 1.5.0 deprecates the OIDC Provider plugin in favor of an OAuth 2.1 provider — irrelevant to us today, but don't adopt `oidcProvider` in new work.
- **DB schema / migrations:** no schema change for our config. A fresh 1.6.25 migration against a throwaway Postgres creates exactly the same four tables/columns (`user`, `session`, `account`, `verification`) as 1.4.x, so the boot-time migration on the existing database is a no-op. The direct `"account"` SQL in `/exchange` (columns `providerId`, `accountId`, `userId`, `createdAt`, `updatedAt`) is still valid.
- **Config surface verified against installed 1.6.25 types** (`@better-auth/core` `init-options.d.mts`): `appName`, `baseURL`, `basePath`, `secret`, `trustedOrigins`, `database` (pg `Pool`), `session.expiresIn/updateAge/cookieCache`, `emailAndPassword.enabled/requireEmailVerification`, `socialProviders`, `account.storeStateStrategy`, `account.accountLinking.enabled/trustedProviders`, `advanced.crossSubDomainCookies`, `advanced.defaultCookieAttributes` — all present and behaviorally unchanged. `genericOAuth` `getToken({ code, redirectURI, codeVerifier? })` / `getUserInfo(tokens)` hooks unchanged. `toNodeHandler` / `fromNodeHeaders` / `auth.api.getSession({ headers })` unchanged.

## Verification performed

- `npm audit`: 0 vulnerabilities (was 1 critical / 3 high / 3 moderate).
- `node --check` on all five `src/*.js` files: pass.
- Migration dry-run against a throwaway Postgres 16 container using the real `authConfig`: plan → `runMigrations()` → re-plan reports 0 pending; `/exchange` account query validated against the migrated schema.
- Local login-path smoke against the throwaway Postgres with the real `auth.js`/`exchange.js` and the same express wiring as `server.js` (secrets service bypassed, throwaway ES256 keypair): email+password sign-up → session cookie issued with the exact configured attributes → `get-session` returns the user → `POST /exchange` returns an ES256 token that verifies against the public key with the expected `purpose`/`provider`/`providers` claims.

## Remains manual before merge (chunk acceptance criterion)

The **end-to-end compose login smoke test has NOT been run** — it requires real OAuth provider credentials and the production ES256 keypair, which are not available to automation. A human must run, per the P0.6 spec: `docker compose -f deploy/compose/docker-compose.services.yml up` → social OAuth login with a configured provider → ES256 `/exchange` → Identity `/exchange` → JWT accepted by the Gateway, and verify account linking and the session cookie. Also allow a Dependabot scan cycle after merge and confirm alert closure via `gh api /repos/SandboxServers/MeridianConsole/dependabot/alerts?state=open`.

No automated test suite exists for this service (known gap per `src/Dhadgar.BetterAuth/CLAUDE.md`; per the P0.6 spec, building one is out of scope for this phase).

Part of #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGdu91QcJ9qCxa1a2qz6gb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication startup migrations to remain compatible with the latest Better Auth release.
  * Improved migration logging for newly added fields, ensuring details are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->