### PR TITLE
security(P0): fix critical credential and access control vulnerabilities (supersedes #127)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />

--- a/src/Agents/Dhadgar.Agent.Core/packages.lock.json
+++ b/src/Agents/Dhadgar.Agent.Core/packages.lock.json
@@ -237,15 +237,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -313,14 +304,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -627,6 +610,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Agents/Dhadgar.Agent.GameServerWrapper/packages.lock.json
+++ b/src/Agents/Dhadgar.Agent.GameServerWrapper/packages.lock.json
@@ -150,15 +150,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -226,14 +217,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -575,6 +558,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/src/Agents/Dhadgar.Agent.Linux/packages.lock.json
+++ b/src/Agents/Dhadgar.Agent.Linux/packages.lock.json
@@ -126,15 +126,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -202,14 +193,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -543,6 +526,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/src/Agents/Dhadgar.Agent.Windows/packages.lock.json
+++ b/src/Agents/Dhadgar.Agent.Windows/packages.lock.json
@@ -150,15 +150,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -226,14 +217,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -575,6 +558,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/src/Dhadgar.AppHost/packages.lock.json
+++ b/src/Dhadgar.AppHost/packages.lock.json
@@ -314,15 +314,6 @@
         "resolved": "2.5.192",
         "contentHash": "jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg=="
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
-          "Microsoft.Extensions.Primitives": "10.0.1"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.1",
@@ -390,14 +381,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.1"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -702,6 +685,25 @@
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "StackExchange.Redis": "2.7.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/src/Dhadgar.Billing/appsettings.json
+++ b/src/Dhadgar.Billing/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Dhadgar.Console/appsettings.json
+++ b/src/Dhadgar.Console/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Dhadgar.Discord/appsettings.json
+++ b/src/Dhadgar.Discord/appsettings.json
@@ -7,12 +7,12 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   },
   "SecretsService": {
     "Url": "http://localhost:5110"

--- a/src/Dhadgar.Files/appsettings.json
+++ b/src/Dhadgar.Files/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Dhadgar.Identity/Program.cs
+++ b/src/Dhadgar.Identity/Program.cs
@@ -223,8 +223,10 @@ if (builder.Environment.IsEnvironment("Testing"))
 }
 else
 {
-    // Load gaming OAuth secrets from Secrets Service at startup
-    var secretsServiceUrl = builder.Configuration["SecretsService:Url"] ?? "http://localhost:5000";
+    // Load gaming OAuth secrets from Secrets Service at startup.
+    // Identity calls the Secrets service directly (not via the Gateway) — deployment
+    // config points SecretsService__Url at the Secrets container; 5110 is its local port.
+    var secretsServiceUrl = builder.Configuration["SecretsService:Url"] ?? "http://localhost:5110";
     using var oauthSecrets = new OAuthSecretProvider(new Uri(secretsServiceUrl));
     await oauthSecrets.LoadSecretsAsync();
 
@@ -965,13 +967,38 @@ static async Task SeedServiceAccountAsync(
 
     if (string.IsNullOrWhiteSpace(clientSecret))
     {
-        using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-        var secretBytes = new byte[32];
-        rng.GetBytes(secretBytes);
-        clientSecret = Convert.ToBase64String(secretBytes);
+        // Accounts that authenticate via client_credentials need a secret the calling
+        // service also knows. Seeding a random hashed secret would permanently brick
+        // the account (the FindByClientIdAsync guard below prevents re-seeding), so
+        // warn and skip instead — matching the SeedDevOpenIddictClientAsync pattern.
+        // The account will be seeded on a later startup once the secret is configured.
+        var isWifOnly = scopes is ["wif"];
+        if (!isWifOnly)
+        {
+            logger.LogWarning(
+                "Service account {ServiceKey} has no configured ClientSecret; skipping seed to avoid " +
+                "registering an unusable client_credentials account. Set {ConfigSection}:ClientSecret " +
+                "(or disable with {ConfigSection}:Enabled=false); it will be seeded on the next startup.",
+                serviceKey, configSection, configSection);
+            return;
+        }
+
+        // WIF-only accounts exist as federated-credential subjects; a random placeholder
+        // secret is acceptable because federation, not the secret, authenticates them.
+        var secretBytes = System.Security.Cryptography.RandomNumberGenerator.GetBytes(32);
+        try
+        {
+            clientSecret = Convert.ToBase64String(secretBytes);
+        }
+        finally
+        {
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(secretBytes);
+        }
+
         logger.LogWarning(
-            "Service account {ServiceKey} has no configured ClientSecret. A random secret was generated. " +
-            "Configure {ConfigSection}:ClientSecret explicitly for production use.",
+            "WIF-only service account {ServiceKey} has no configured ClientSecret. A random placeholder " +
+            "was generated; the account cannot authenticate via client_credentials until " +
+            "{ConfigSection}:ClientSecret is configured explicitly.",
             serviceKey, configSection);
     }
 

--- a/src/Dhadgar.Identity/appsettings.json
+++ b/src/Dhadgar.Identity/appsettings.json
@@ -6,14 +6,14 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password="
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "Redis": {
     "ConnectionString": "localhost:6379"
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
+    "Username": "",
     "Password": ""
   },
   "SecretsService": {

--- a/src/Dhadgar.Identity/appsettings.json
+++ b/src/Dhadgar.Identity/appsettings.json
@@ -17,7 +17,7 @@
     "Password": ""
   },
   "SecretsService": {
-    "Url": "http://localhost:5000"
+    "Url": "http://localhost:5110"
   },
   "Auth": {
     "Issuer": "https://meridianconsole.com/api/v1/identity",

--- a/src/Dhadgar.Mods/appsettings.json
+++ b/src/Dhadgar.Mods/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Dhadgar.Nodes/RabbitMqOptions.cs
+++ b/src/Dhadgar.Nodes/RabbitMqOptions.cs
@@ -13,10 +13,10 @@ public sealed class RabbitMqOptions
     public string Host { get; set; } = "localhost";
 
     [Required]
-    public string Username { get; set; } = "dhadgar";
+    public string Username { get; set; } = string.Empty;
 
     [Required]
-    public string Password { get; set; } = "dhadgar";
+    public string Password { get; set; } = string.Empty;
 
     public string VirtualHost { get; set; } = "/";
 }

--- a/src/Dhadgar.Nodes/appsettings.json
+++ b/src/Dhadgar.Nodes/appsettings.json
@@ -6,12 +6,12 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   },
   "Nodes": {
     "HeartbeatThresholdMinutes": 5,

--- a/src/Dhadgar.Notifications/appsettings.json
+++ b/src/Dhadgar.Notifications/appsettings.json
@@ -7,12 +7,12 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_notifications;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_notifications;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   },
   "Discord": {
     "WebhookUrl": "",

--- a/src/Dhadgar.Secrets/Authorization/IBreakGlassNonceTracker.cs
+++ b/src/Dhadgar.Secrets/Authorization/IBreakGlassNonceTracker.cs
@@ -1,0 +1,13 @@
+namespace Dhadgar.Secrets.Authorization;
+
+/// <summary>
+/// Tracks break-glass token nonces to enforce single-use semantics.
+/// </summary>
+public interface IBreakGlassNonceTracker
+{
+    /// <summary>
+    /// Attempts to consume a nonce. Returns true if the nonce was valid and has not been used before.
+    /// Returns false if the nonce has already been consumed (replay).
+    /// </summary>
+    Task<bool> TryConsumeNonceAsync(string nonce);
+}

--- a/src/Dhadgar.Secrets/Authorization/IBreakGlassNonceTracker.cs
+++ b/src/Dhadgar.Secrets/Authorization/IBreakGlassNonceTracker.cs
@@ -2,12 +2,27 @@ namespace Dhadgar.Secrets.Authorization;
 
 /// <summary>
 /// Tracks break-glass token nonces to enforce single-use semantics.
+/// <para>
+/// Production deployments running more than one instance MUST use a durable,
+/// strongly-consistent implementation (e.g., Redis- or database-backed): a
+/// per-process store cannot detect a nonce consumed on another replica or
+/// before a restart.
+/// </para>
 /// </summary>
 public interface IBreakGlassNonceTracker
 {
     /// <summary>
     /// Attempts to consume a nonce. Returns true if the nonce was valid and has not been used before.
     /// Returns false if the nonce has already been consumed (replay).
+    /// <para>
+    /// Contract: <paramref name="nonce"/> must be non-null, non-empty, and not whitespace-only.
+    /// Callers are expected to reject tokens with missing or blank nonce claims before
+    /// consulting the tracker; a blank value must never be "consumed" (doing so would
+    /// permanently replay-reject every subsequent token carrying a blank nonce).
+    /// </para>
     /// </summary>
+    /// <param name="nonce">The single-use nonce value from the break-glass token. Must not be null, empty, or whitespace.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="nonce"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="nonce"/> is empty or whitespace-only.</exception>
     Task<bool> TryConsumeNonceAsync(string nonce);
 }

--- a/src/Dhadgar.Secrets/Authorization/ISecretsAuthorizationService.cs
+++ b/src/Dhadgar.Secrets/Authorization/ISecretsAuthorizationService.cs
@@ -3,6 +3,25 @@ using System.Security.Claims;
 namespace Dhadgar.Secrets.Authorization;
 
 /// <summary>
+/// Centralized break-glass policy constants shared by the authorization service
+/// and the nonce tracker, so their timing invariants cannot drift apart.
+/// </summary>
+public static class BreakGlassPolicy
+{
+    /// <summary>
+    /// Maximum time-to-live a break-glass token may declare via <c>break_glass_exp</c>.
+    /// </summary>
+    public static readonly TimeSpan MaxTtl = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// How long consumed nonces must be retained for replay detection.
+    /// Derived from <see cref="MaxTtl"/> (2x) so that a nonce is never evicted
+    /// while a token carrying it could still be within its validity window.
+    /// </summary>
+    public static readonly TimeSpan NonceRetentionPeriod = MaxTtl * 2;
+}
+
+/// <summary>
 /// Service for authorizing access to secrets.
 /// Supports permission hierarchy, service accounts, and break-glass access.
 /// </summary>
@@ -10,13 +29,17 @@ public interface ISecretsAuthorizationService
 {
     /// <summary>
     /// Checks if the user is authorized to perform the specified action on a secret.
+    /// Asynchronous because break-glass validation consumes a single-use nonce via
+    /// <see cref="IBreakGlassNonceTracker"/>, which may be backed by a distributed store.
     /// </summary>
-    AuthorizationResult Authorize(ClaimsPrincipal user, string secretName, SecretAction action);
+    Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, string secretName, SecretAction action);
 
     /// <summary>
     /// Checks if the user is authorized to access a category of secrets.
+    /// Asynchronous because break-glass validation consumes a single-use nonce via
+    /// <see cref="IBreakGlassNonceTracker"/>, which may be backed by a distributed store.
     /// </summary>
-    AuthorizationResult AuthorizeCategory(ClaimsPrincipal user, string category, SecretAction action);
+    Task<AuthorizationResult> AuthorizeCategoryAsync(ClaimsPrincipal user, string category, SecretAction action);
 }
 
 public enum SecretAction

--- a/src/Dhadgar.Secrets/Authorization/InMemoryBreakGlassNonceTracker.cs
+++ b/src/Dhadgar.Secrets/Authorization/InMemoryBreakGlassNonceTracker.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+
+namespace Dhadgar.Secrets.Authorization;
+
+/// <summary>
+/// In-memory break-glass nonce tracker with automatic expiry cleanup.
+/// For multi-instance deployments, replace with a distributed implementation (e.g., Redis-backed).
+/// </summary>
+public sealed class InMemoryBreakGlassNonceTracker : IBreakGlassNonceTracker, IDisposable
+{
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _consumedNonces = new();
+    private readonly Timer _cleanupTimer;
+    private readonly TimeSpan _retentionPeriod = TimeSpan.FromHours(2);
+
+    public InMemoryBreakGlassNonceTracker()
+    {
+        _cleanupTimer = new Timer(Cleanup, null, TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(10));
+    }
+
+    public Task<bool> TryConsumeNonceAsync(string nonce)
+    {
+        var consumed = _consumedNonces.TryAdd(nonce, DateTimeOffset.UtcNow);
+        return Task.FromResult(consumed);
+    }
+
+    private void Cleanup(object? state)
+    {
+        var cutoff = DateTimeOffset.UtcNow - _retentionPeriod;
+        foreach (var kvp in _consumedNonces)
+        {
+            if (kvp.Value < cutoff)
+            {
+                _consumedNonces.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cleanupTimer.Dispose();
+    }
+}

--- a/src/Dhadgar.Secrets/Authorization/InMemoryBreakGlassNonceTracker.cs
+++ b/src/Dhadgar.Secrets/Authorization/InMemoryBreakGlassNonceTracker.cs
@@ -4,34 +4,58 @@ namespace Dhadgar.Secrets.Authorization;
 
 /// <summary>
 /// In-memory break-glass nonce tracker with automatic expiry cleanup.
-/// For multi-instance deployments, replace with a distributed implementation (e.g., Redis-backed).
+/// <para>
+/// Suitable for single-instance deployments only: nonces are per-process, so
+/// replicas and restarts defeat the single-use guarantee. For multi-instance
+/// deployments, replace with a distributed implementation (e.g., Redis-backed).
+/// </para>
 /// </summary>
 public sealed class InMemoryBreakGlassNonceTracker : IBreakGlassNonceTracker, IDisposable
 {
     private readonly ConcurrentDictionary<string, DateTimeOffset> _consumedNonces = new();
     private readonly Timer _cleanupTimer;
-    private readonly TimeSpan _retentionPeriod = TimeSpan.FromHours(2);
+    private readonly ILogger<InMemoryBreakGlassNonceTracker>? _logger;
 
-    public InMemoryBreakGlassNonceTracker()
+    // Derived from the break-glass max TTL so a nonce can never be evicted while a
+    // token carrying it is still within its validity window.
+    private readonly TimeSpan _retentionPeriod = BreakGlassPolicy.NonceRetentionPeriod;
+
+    public InMemoryBreakGlassNonceTracker(ILogger<InMemoryBreakGlassNonceTracker>? logger = null)
     {
+        _logger = logger;
         _cleanupTimer = new Timer(Cleanup, null, TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(10));
     }
 
+    /// <inheritdoc />
     public Task<bool> TryConsumeNonceAsync(string nonce)
     {
+        // Enforce the interface contract explicitly: a blank nonce must never be
+        // "consumed" (that would permanently replay-reject all blank-nonce tokens),
+        // and null would otherwise surface as an opaque ConcurrentDictionary error.
+        ArgumentException.ThrowIfNullOrWhiteSpace(nonce);
+
         var consumed = _consumedNonces.TryAdd(nonce, DateTimeOffset.UtcNow);
         return Task.FromResult(consumed);
     }
 
     private void Cleanup(object? state)
     {
-        var cutoff = DateTimeOffset.UtcNow - _retentionPeriod;
-        foreach (var kvp in _consumedNonces)
+        try
         {
-            if (kvp.Value < cutoff)
+            var cutoff = DateTimeOffset.UtcNow - _retentionPeriod;
+            foreach (var kvp in _consumedNonces)
             {
-                _consumedNonces.TryRemove(kvp.Key, out _);
+                if (kvp.Value < cutoff)
+                {
+                    _consumedNonces.TryRemove(kvp.Key, out _);
+                }
             }
+        }
+        catch (Exception ex)
+        {
+            // Never let an exception escape the timer callback: it would silently
+            // kill the cleanup timer and nonce retention would grow unbounded.
+            _logger?.LogError(ex, "Break-glass nonce cleanup failed; will retry on next timer tick.");
         }
     }
 

--- a/src/Dhadgar.Secrets/Authorization/SecretsAuthorizationService.cs
+++ b/src/Dhadgar.Secrets/Authorization/SecretsAuthorizationService.cs
@@ -11,7 +11,7 @@ namespace Dhadgar.Secrets.Authorization;
 /// </summary>
 public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
 {
-    private static readonly TimeSpan MaxBreakGlassTtl = TimeSpan.FromHours(1);
+    private static readonly TimeSpan MaxBreakGlassTtl = BreakGlassPolicy.MaxTtl;
 
     private readonly SecretsOptions _options;
     private readonly IBreakGlassNonceTracker _nonceTracker;
@@ -27,7 +27,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
         _logger = logger;
     }
 
-    public AuthorizationResult Authorize(ClaimsPrincipal user, string secretName, SecretAction action)
+    public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, string secretName, SecretAction action)
     {
         var userId = user.FindFirstValue("sub");
         var principalType = user.FindFirstValue("principal_type") ?? "user";
@@ -42,7 +42,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
         // Check break-glass access
         if (user.HasClaim("break_glass", "true"))
         {
-            return ValidateBreakGlassAccess(user, userId, principalType, isServiceAccount, secretName);
+            return await ValidateBreakGlassAccessAsync(user, userId, principalType, isServiceAccount, secretName);
         }
 
         // Determine the category of the secret
@@ -84,7 +84,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
             userId);
     }
 
-    public AuthorizationResult AuthorizeCategory(ClaimsPrincipal user, string category, SecretAction action)
+    public async Task<AuthorizationResult> AuthorizeCategoryAsync(ClaimsPrincipal user, string category, SecretAction action)
     {
         var userId = user.FindFirstValue("sub");
         var principalType = user.FindFirstValue("principal_type") ?? "user";
@@ -98,7 +98,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
         // Check break-glass
         if (user.HasClaim("break_glass", "true"))
         {
-            return ValidateBreakGlassAccess(user, userId, principalType, isServiceAccount, $"category:{category}");
+            return await ValidateBreakGlassAccessAsync(user, userId, principalType, isServiceAccount, $"category:{category}");
         }
 
         var actionStr = action.ToString().ToLowerInvariant();
@@ -123,13 +123,17 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
             userId);
     }
 
-    private AuthorizationResult ValidateBreakGlassAccess(
+    private async Task<AuthorizationResult> ValidateBreakGlassAccessAsync(
         ClaimsPrincipal user,
         string? userId,
         string principalType,
         bool isServiceAccount,
         string resourceName)
     {
+        // Capture the clock once so the max-TTL and expiry checks below evaluate
+        // against the same instant (avoids a tiny race between two UtcNow reads).
+        var now = DateTimeOffset.UtcNow;
+
         // Require expiration claim
         var expClaim = user.FindFirstValue("break_glass_exp");
         if (string.IsNullOrWhiteSpace(expClaim))
@@ -149,7 +153,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
         }
 
         var expiration = DateTimeOffset.FromUnixTimeSeconds(expUnix);
-        if (expiration > DateTimeOffset.UtcNow + MaxBreakGlassTtl)
+        if (expiration > now + MaxBreakGlassTtl)
         {
             _logger.LogWarning(
                 "Break-glass access DENIED for {ResourceName} by {UserId}: expiration exceeds maximum TTL of {MaxTtl}.",
@@ -157,7 +161,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
             return AuthorizationResult.Denied($"Break-glass token TTL exceeds maximum of {MaxBreakGlassTtl.TotalMinutes} minutes.", userId);
         }
 
-        if (expiration <= DateTimeOffset.UtcNow)
+        if (expiration <= now)
         {
             _logger.LogWarning(
                 "Break-glass access DENIED for {ResourceName} by {UserId}: token has expired at {Expiration}.",
@@ -175,7 +179,7 @@ public sealed class SecretsAuthorizationService : ISecretsAuthorizationService
             return AuthorizationResult.Denied("Break-glass token must include a single-use nonce (break_glass_nonce).", userId);
         }
 
-        if (!_nonceTracker.TryConsumeNonceAsync(nonce).GetAwaiter().GetResult())
+        if (!await _nonceTracker.TryConsumeNonceAsync(nonce))
         {
             _logger.LogWarning(
                 "Break-glass access DENIED for {ResourceName} by {UserId}: nonce {Nonce} has already been consumed (replay attempt).",

--- a/src/Dhadgar.Secrets/Endpoints/SecretWriteEndpoints.cs
+++ b/src/Dhadgar.Secrets/Endpoints/SecretWriteEndpoints.cs
@@ -80,7 +80,7 @@ public static class SecretWriteEndpoints
         }
 
         // Authorize
-        var authResult = authService.Authorize(context.User, secretName, SecretAction.Write);
+        var authResult = await authService.AuthorizeAsync(context.User, secretName, SecretAction.Write);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(
@@ -161,7 +161,7 @@ public static class SecretWriteEndpoints
         }
 
         // Authorize - rotation requires specific permission
-        var authResult = authService.Authorize(context.User, secretName, SecretAction.Rotate);
+        var authResult = await authService.AuthorizeAsync(context.User, secretName, SecretAction.Rotate);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(
@@ -254,7 +254,7 @@ public static class SecretWriteEndpoints
         }
 
         // Authorize - delete requires write permission
-        var authResult = authService.Authorize(context.User, secretName, SecretAction.Delete);
+        var authResult = await authService.AuthorizeAsync(context.User, secretName, SecretAction.Delete);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(

--- a/src/Dhadgar.Secrets/Endpoints/SecretsEndpoints.cs
+++ b/src/Dhadgar.Secrets/Endpoints/SecretsEndpoints.cs
@@ -84,7 +84,7 @@ public static class SecretsEndpoints
         }
 
         // Authorize
-        var authResult = authService.Authorize(context.User, secretName, SecretAction.Read);
+        var authResult = await authService.AuthorizeAsync(context.User, secretName, SecretAction.Read);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(
@@ -170,7 +170,7 @@ public static class SecretsEndpoints
                 continue;
             }
 
-            var authResult = authService.Authorize(context.User, secretName, SecretAction.Read);
+            var authResult = await authService.AuthorizeAsync(context.User, secretName, SecretAction.Read);
             if (authResult.IsAuthorized)
             {
                 authorizedSecrets.Add(secretName);
@@ -213,7 +213,7 @@ public static class SecretsEndpoints
         HttpContext context,
         CancellationToken ct)
     {
-        var authResult = authService.AuthorizeCategory(context.User, "oauth", SecretAction.Read);
+        var authResult = await authService.AuthorizeCategoryAsync(context.User, "oauth", SecretAction.Read);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(
@@ -250,7 +250,7 @@ public static class SecretsEndpoints
         HttpContext context,
         CancellationToken ct)
     {
-        var authResult = authService.AuthorizeCategory(context.User, "betterauth", SecretAction.Read);
+        var authResult = await authService.AuthorizeCategoryAsync(context.User, "betterauth", SecretAction.Read);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(
@@ -287,7 +287,7 @@ public static class SecretsEndpoints
         HttpContext context,
         CancellationToken ct)
     {
-        var authResult = authService.AuthorizeCategory(context.User, "infrastructure", SecretAction.Read);
+        var authResult = await authService.AuthorizeCategoryAsync(context.User, "infrastructure", SecretAction.Read);
         if (!authResult.IsAuthorized)
         {
             auditLogger.LogAccessDenied(new SecretAccessDeniedEvent(

--- a/src/Dhadgar.Secrets/Program.cs
+++ b/src/Dhadgar.Secrets/Program.cs
@@ -114,6 +114,7 @@ builder.Services.AddHealthChecks()
     .AddCheck<SecretsReadinessCheck>("secrets_ready", tags: ["ready"]);
 
 // Register authorization and audit services
+builder.Services.AddSingleton<IBreakGlassNonceTracker, InMemoryBreakGlassNonceTracker>();
 builder.Services.AddSingleton<ISecretsAuthorizationService, SecretsAuthorizationService>();
 builder.Services.AddSingleton<ISecretsAuditLogger, SecretsAuditLogger>();
 

--- a/src/Dhadgar.Secrets/Program.cs
+++ b/src/Dhadgar.Secrets/Program.cs
@@ -114,6 +114,10 @@ builder.Services.AddHealthChecks()
     .AddCheck<SecretsReadinessCheck>("secrets_ready", tags: ["ready"]);
 
 // Register authorization and audit services
+// NOTE: InMemoryBreakGlassNonceTracker is safe for single-instance deployments only.
+// Its per-process store cannot detect nonces consumed on other replicas or before a
+// restart, so multi-instance production deployments must swap in a distributed
+// implementation (e.g., Redis-backed). Tracked as a P0.4 follow-up of issue #129.
 builder.Services.AddSingleton<IBreakGlassNonceTracker, InMemoryBreakGlassNonceTracker>();
 builder.Services.AddSingleton<ISecretsAuthorizationService, SecretsAuthorizationService>();
 builder.Services.AddSingleton<ISecretsAuditLogger, SecretsAuditLogger>();

--- a/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
+++ b/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
@@ -86,7 +86,8 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
     {
         var wifConfig = _options.Wif!;
         var httpClient = _httpClientFactory.CreateClient("IdentityWif");
-        var serviceClientId = wifConfig.ServiceClientId ?? "dev-client";
+        var serviceClientId = wifConfig.ServiceClientId
+            ?? throw new InvalidOperationException("Secrets:Wif:ServiceClientId is required for WIF authentication.");
 
         _logger.LogInformation(
             "Requesting WIF token from Identity service: Endpoint={Endpoint}, ServiceClientId={ServiceClientId}",
@@ -98,7 +99,8 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
         {
             ["grant_type"] = "client_credentials",
             ["client_id"] = serviceClientId,
-            ["client_secret"] = wifConfig.ServiceClientSecret ?? "dev-secret",
+            ["client_secret"] = wifConfig.ServiceClientSecret
+                ?? throw new InvalidOperationException("Secrets:Wif:ServiceClientSecret is required for WIF authentication."),
             ["scope"] = "wif"
         });
 

--- a/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
+++ b/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
@@ -86,8 +86,20 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
     {
         var wifConfig = _options.Wif!;
         var httpClient = _httpClientFactory.CreateClient("IdentityWif");
-        var serviceClientId = wifConfig.ServiceClientId
-            ?? throw new InvalidOperationException("Secrets:Wif:ServiceClientId is required for WIF authentication.");
+
+        // Fail fast: reject missing, empty, and whitespace-only values.
+        // A null-coalescing check is not enough — cleared configuration values are "" (not null).
+        var serviceClientId = wifConfig.ServiceClientId;
+        if (string.IsNullOrWhiteSpace(serviceClientId))
+        {
+            throw new InvalidOperationException("Secrets:Wif:ServiceClientId is required for WIF authentication.");
+        }
+
+        var serviceClientSecret = wifConfig.ServiceClientSecret;
+        if (string.IsNullOrWhiteSpace(serviceClientSecret))
+        {
+            throw new InvalidOperationException("Secrets:Wif:ServiceClientSecret is required for WIF authentication.");
+        }
 
         _logger.LogInformation(
             "Requesting WIF token from Identity service: Endpoint={Endpoint}, ServiceClientId={ServiceClientId}",
@@ -99,8 +111,7 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
         {
             ["grant_type"] = "client_credentials",
             ["client_id"] = serviceClientId,
-            ["client_secret"] = wifConfig.ServiceClientSecret
-                ?? throw new InvalidOperationException("Secrets:Wif:ServiceClientSecret is required for WIF authentication."),
+            ["client_secret"] = serviceClientSecret,
             ["scope"] = "wif"
         });
 

--- a/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
+++ b/src/Dhadgar.Secrets/Services/WifCredentialProvider.cs
@@ -73,7 +73,7 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
             wifConfig.TenantId,
             wifConfig.ClientId,
             wifConfig.IdentityTokenEndpoint,
-            wifConfig.ServiceClientId ?? "(default)");
+            string.IsNullOrWhiteSpace(wifConfig.ServiceClientId) ? "(not configured)" : wifConfig.ServiceClientId);
 
         // Create a ClientAssertionCredential that gets tokens from our Identity service
         return new ClientAssertionCredential(
@@ -82,6 +82,10 @@ public sealed class WifCredentialProvider : IWifCredentialProvider
             async (ct) => await GetIdentityTokenAsync(ct));
     }
 
+    // NOTE: This method intentionally throws instead of returning Result<T>. It is the
+    // assertion callback for Azure's ClientAssertionCredential, whose signature mandates
+    // Task<string> — there is no channel to surface a Result. The Azure SDK converts
+    // exceptions thrown here into credential/authentication failures for callers.
     private async Task<string> GetIdentityTokenAsync(CancellationToken ct)
     {
         var wifConfig = _options.Wif!;

--- a/src/Dhadgar.Secrets/appsettings.json
+++ b/src/Dhadgar.Secrets/appsettings.json
@@ -14,12 +14,12 @@
     "KeyVaultUri": "https://mc-oauth.vault.azure.net/"
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   },
   "Readiness": {
     "ProbeSecretName": "",

--- a/src/Dhadgar.Servers/appsettings.json
+++ b/src/Dhadgar.Servers/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Dhadgar.Tasks/appsettings.json
+++ b/src/Dhadgar.Tasks/appsettings.json
@@ -6,11 +6,11 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar"
+    "Postgres": "Host=localhost;Port=5432;Database=dhadgar_platform;Username=;Password="
   },
   "RabbitMq": {
     "Host": "localhost",
-    "Username": "dhadgar",
-    "Password": "dhadgar"
+    "Username": "",
+    "Password": ""
   }
 }

--- a/src/Shared/Dhadgar.Messaging/MessagingExtensions.cs
+++ b/src/Shared/Dhadgar.Messaging/MessagingExtensions.cs
@@ -71,8 +71,10 @@ public static class MessagingExtensions
             x.UsingRabbitMq((ctx, cfg) =>
             {
                 var host = config["RabbitMq:Host"] ?? config.GetConnectionString("RabbitMqHost") ?? "localhost";
-                var user = config["RabbitMq:Username"] ?? "dhadgar";
-                var pass = config["RabbitMq:Password"] ?? "dhadgar";
+                var user = config["RabbitMq:Username"]
+                    ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
+                var pass = config["RabbitMq:Password"]
+                    ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
 
                 cfg.Host(host, h =>
                 {

--- a/src/Shared/Dhadgar.Messaging/MessagingExtensions.cs
+++ b/src/Shared/Dhadgar.Messaging/MessagingExtensions.cs
@@ -49,11 +49,15 @@ public static class MessagingExtensions
     /// Configuration keys:
     /// <list type="bullet">
     ///   <item><description><c>RabbitMq:Host</c> - RabbitMQ host (default: localhost)</description></item>
-    ///   <item><description><c>RabbitMq:Username</c> - Username (default: dhadgar)</description></item>
-    ///   <item><description><c>RabbitMq:Password</c> - Password (default: dhadgar)</description></item>
+    ///   <item><description><c>RabbitMq:Username</c> - Username (required; no default)</description></item>
+    ///   <item><description><c>RabbitMq:Password</c> - Password (required; no default)</description></item>
     /// </list>
     /// </para>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown at bus creation (host startup) when <c>RabbitMq:Username</c> or
+    /// <c>RabbitMq:Password</c> is missing, empty, or whitespace.
+    /// </exception>
     public static IServiceCollection AddDhadgarMessaging(
         this IServiceCollection services,
         IConfiguration config,
@@ -71,10 +75,23 @@ public static class MessagingExtensions
             x.UsingRabbitMq((ctx, cfg) =>
             {
                 var host = config["RabbitMq:Host"] ?? config.GetConnectionString("RabbitMqHost") ?? "localhost";
-                var user = config["RabbitMq:Username"]
-                    ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
-                var pass = config["RabbitMq:Password"]
-                    ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
+
+                // Fail fast at bus creation (host startup): reject missing, empty, and
+                // whitespace-only credentials. A null-coalescing check is not enough —
+                // cleared appsettings values are "" (not null), so `?? throw` never fires.
+                var user = config["RabbitMq:Username"];
+                if (string.IsNullOrWhiteSpace(user))
+                {
+                    throw new InvalidOperationException(
+                        "RabbitMq:Username is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+                }
+
+                var pass = config["RabbitMq:Password"];
+                if (string.IsNullOrWhiteSpace(pass))
+                {
+                    throw new InvalidOperationException(
+                        "RabbitMq:Password is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+                }
 
                 cfg.Host(host, h =>
                 {

--- a/src/Shared/Dhadgar.ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/src/Shared/Dhadgar.ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -196,8 +196,10 @@ public static class ServiceDefaultsExtensions
         if (dependencies.HasFlag(HealthCheckDependencies.RabbitMq))
         {
             var rabbitHost = builder.Configuration["RabbitMq:Host"] ?? "localhost";
-            var rabbitUser = builder.Configuration["RabbitMq:Username"] ?? "dhadgar";
-            var rabbitPass = builder.Configuration["RabbitMq:Password"] ?? "dhadgar";
+            var rabbitUser = builder.Configuration["RabbitMq:Username"]
+                ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
+            var rabbitPass = builder.Configuration["RabbitMq:Password"]
+                ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
 
             healthChecks.AddRabbitMQ(
                 factory: async _ =>
@@ -350,8 +352,10 @@ public static class ServiceDefaultsExtensions
         if (dependencies.HasFlag(HealthCheckDependencies.RabbitMq))
         {
             var rabbitHost = configuration["RabbitMq:Host"] ?? "localhost";
-            var rabbitUser = configuration["RabbitMq:Username"] ?? "dhadgar";
-            var rabbitPass = configuration["RabbitMq:Password"] ?? "dhadgar";
+            var rabbitUser = configuration["RabbitMq:Username"]
+                ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
+            var rabbitPass = configuration["RabbitMq:Password"]
+                ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
 
             healthChecks.AddRabbitMQ(
                 factory: async _ =>

--- a/src/Shared/Dhadgar.ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/src/Shared/Dhadgar.ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -196,10 +196,22 @@ public static class ServiceDefaultsExtensions
         if (dependencies.HasFlag(HealthCheckDependencies.RabbitMq))
         {
             var rabbitHost = builder.Configuration["RabbitMq:Host"] ?? "localhost";
-            var rabbitUser = builder.Configuration["RabbitMq:Username"]
-                ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
-            var rabbitPass = builder.Configuration["RabbitMq:Password"]
-                ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
+
+            // Fail fast: reject missing, empty, and whitespace-only credentials.
+            // A null-coalescing check is not enough — cleared appsettings values are "" (not null).
+            var rabbitUser = builder.Configuration["RabbitMq:Username"];
+            if (string.IsNullOrWhiteSpace(rabbitUser))
+            {
+                throw new InvalidOperationException(
+                    "RabbitMq:Username is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+            }
+
+            var rabbitPass = builder.Configuration["RabbitMq:Password"];
+            if (string.IsNullOrWhiteSpace(rabbitPass))
+            {
+                throw new InvalidOperationException(
+                    "RabbitMq:Password is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+            }
 
             healthChecks.AddRabbitMQ(
                 factory: async _ =>
@@ -352,10 +364,22 @@ public static class ServiceDefaultsExtensions
         if (dependencies.HasFlag(HealthCheckDependencies.RabbitMq))
         {
             var rabbitHost = configuration["RabbitMq:Host"] ?? "localhost";
-            var rabbitUser = configuration["RabbitMq:Username"]
-                ?? throw new InvalidOperationException("RabbitMq:Username is required. Configure via environment variables, user-secrets, or appsettings.");
-            var rabbitPass = configuration["RabbitMq:Password"]
-                ?? throw new InvalidOperationException("RabbitMq:Password is required. Configure via environment variables, user-secrets, or appsettings.");
+
+            // Fail fast: reject missing, empty, and whitespace-only credentials.
+            // A null-coalescing check is not enough — cleared appsettings values are "" (not null).
+            var rabbitUser = configuration["RabbitMq:Username"];
+            if (string.IsNullOrWhiteSpace(rabbitUser))
+            {
+                throw new InvalidOperationException(
+                    "RabbitMq:Username is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+            }
+
+            var rabbitPass = configuration["RabbitMq:Password"];
+            if (string.IsNullOrWhiteSpace(rabbitPass))
+            {
+                throw new InvalidOperationException(
+                    "RabbitMq:Password is required and must not be empty or whitespace. Configure via environment variables, user-secrets, or appsettings.");
+            }
 
             healthChecks.AddRabbitMQ(
                 factory: async _ =>

--- a/src/Shared/Dhadgar.Shared/packages.lock.json
+++ b/src/Shared/Dhadgar.Shared/packages.lock.json
@@ -64,14 +64,6 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -100,6 +92,15 @@
         "type": "Transitive",
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Shared/Dhadgar.Testing/packages.lock.json
+++ b/src/Shared/Dhadgar.Testing/packages.lock.json
@@ -70,15 +70,6 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -146,14 +137,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -363,6 +346,25 @@
           "Microsoft.EntityFrameworkCore.Analyzers": "10.0.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Agent.Core.Tests/packages.lock.json
+++ b/tests/Dhadgar.Agent.Core.Tests/packages.lock.json
@@ -158,15 +158,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -234,14 +225,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -634,6 +617,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Agent.GameServerWrapper.Tests/packages.lock.json
+++ b/tests/Dhadgar.Agent.GameServerWrapper.Tests/packages.lock.json
@@ -181,15 +181,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -257,14 +248,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -676,6 +659,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Agent.Linux.Tests/packages.lock.json
+++ b/tests/Dhadgar.Agent.Linux.Tests/packages.lock.json
@@ -158,15 +158,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -234,14 +225,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -643,6 +626,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Agent.Windows.Tests/packages.lock.json
+++ b/tests/Dhadgar.Agent.Windows.Tests/packages.lock.json
@@ -191,15 +191,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -267,14 +258,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -691,6 +674,25 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.AppHost.Tests/packages.lock.json
+++ b/tests/Dhadgar.AppHost.Tests/packages.lock.json
@@ -317,15 +317,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.1"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
-          "Microsoft.Extensions.Primitives": "10.0.1"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.1",
@@ -393,14 +384,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.1"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -953,6 +936,25 @@
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "StackExchange.Redis": "2.7.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Billing.Tests/packages.lock.json
+++ b/tests/Dhadgar.Billing.Tests/packages.lock.json
@@ -279,15 +279,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -355,14 +346,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1015,6 +998,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Console.Tests/packages.lock.json
+++ b/tests/Dhadgar.Console.Tests/packages.lock.json
@@ -140,15 +140,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -216,14 +207,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -744,6 +727,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Discord.Tests/DiscordWebApplicationFactory.cs
+++ b/tests/Dhadgar.Discord.Tests/DiscordWebApplicationFactory.cs
@@ -61,12 +61,16 @@ public class DiscordWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseEnvironment("Testing");
 
-        // Configure test admin API key
+        // Configure test admin API key and dummy RabbitMQ credentials.
+        // AddDhadgarMessaging fails fast on missing/blank credentials since PR #127;
+        // the bus itself never starts in tests (hosted services are removed below).
         builder.ConfigureAppConfiguration((context, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["AdminApiKey"] = "test-admin-key"
+                ["AdminApiKey"] = "test-admin-key",
+                ["RabbitMq:Username"] = "test-rabbit-user",
+                ["RabbitMq:Password"] = "test-rabbit-password"
             });
         });
 

--- a/tests/Dhadgar.Discord.Tests/packages.lock.json
+++ b/tests/Dhadgar.Discord.Tests/packages.lock.json
@@ -354,15 +354,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -430,14 +421,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1126,6 +1109,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Files.Tests/packages.lock.json
+++ b/tests/Dhadgar.Files.Tests/packages.lock.json
@@ -279,15 +279,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -355,14 +346,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1021,6 +1004,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Gateway.Tests/packages.lock.json
+++ b/tests/Dhadgar.Gateway.Tests/packages.lock.json
@@ -110,15 +110,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -186,14 +177,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -696,6 +679,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Identity.Tests/packages.lock.json
+++ b/tests/Dhadgar.Identity.Tests/packages.lock.json
@@ -352,15 +352,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -428,14 +419,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1531,6 +1514,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Messaging.Tests/Dhadgar.Messaging.Tests.csproj
+++ b/tests/Dhadgar.Messaging.Tests/Dhadgar.Messaging.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/tests/Dhadgar.Messaging.Tests/MessagingExtensionsCredentialValidationTests.cs
+++ b/tests/Dhadgar.Messaging.Tests/MessagingExtensionsCredentialValidationTests.cs
@@ -1,0 +1,99 @@
+using Dhadgar.Messaging.Publishing;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Dhadgar.Messaging.Tests;
+
+/// <summary>
+/// Verifies that <see cref="MessagingExtensions.AddDhadgarMessaging"/> fails fast when
+/// RabbitMQ credentials are missing, empty, or whitespace-only. A plain null-coalescing
+/// check is not sufficient because cleared appsettings values are "" (not null).
+/// Validation runs at bus creation, which is what host startup does — the tests trigger
+/// it by resolving <see cref="IBusControl"/> (the bus is created but never started, so
+/// no broker connection is attempted).
+/// </summary>
+public class MessagingExtensionsCredentialValidationTests
+{
+    private static IConfiguration BuildConfiguration(string? username, string? password)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["RabbitMq:Host"] = "localhost",
+            ["RabbitMq:Username"] = username,
+            ["RabbitMq:Password"] = password
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private static ServiceProvider BuildProvider(IConfiguration config)
+    {
+        var services = new ServiceCollection();
+        services.AddDhadgarMessaging(config);
+        return services.BuildServiceProvider();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddDhadgarMessaging_MissingOrBlankUsername_ThrowsNamingConfigKey(string? username)
+    {
+        using var provider = BuildProvider(BuildConfiguration(username, "valid-password"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IBusControl>());
+
+        Assert.Contains("RabbitMq:Username", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddDhadgarMessaging_MissingOrBlankPassword_ThrowsNamingConfigKey(string? password)
+    {
+        using var provider = BuildProvider(BuildConfiguration("valid-user", password));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IBusControl>());
+
+        Assert.Contains("RabbitMq:Password", ex.Message);
+    }
+
+    [Fact]
+    public void AddDhadgarMessaging_MissingRabbitMqSection_ThrowsNamingConfigKey()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        using var provider = BuildProvider(config);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IBusControl>());
+
+        Assert.Contains("RabbitMq:Username", ex.Message);
+    }
+
+    [Fact]
+    public void AddDhadgarMessaging_ValidCredentials_BusCreationSucceeds()
+    {
+        using var provider = BuildProvider(BuildConfiguration("valid-user", "valid-password"));
+
+        var bus = provider.GetRequiredService<IBusControl>();
+
+        Assert.NotNull(bus);
+    }
+
+    [Fact]
+    public void AddDhadgarMessaging_RegistersEventPublisher()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddDhadgarMessaging(BuildConfiguration("valid-user", "valid-password"));
+
+        Assert.Same(services, result);
+        Assert.Contains(services, d => d.ServiceType == typeof(IEventPublisher));
+    }
+}

--- a/tests/Dhadgar.Messaging.Tests/packages.lock.json
+++ b/tests/Dhadgar.Messaging.Tests/packages.lock.json
@@ -8,6 +8,25 @@
         "resolved": "6.0.4",
         "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.12.0, )",
@@ -47,10 +66,10 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "lqvd7W3FGKUO1+ZoUEMaZ5XDJeWvjpy2/M/ptCGz3tXLD4HWVaSzjufsAsjemasBEg+2SxXVtYVvGt5r2nKDlg==",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "9.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -114,8 +133,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "N3qEBzmLMYiASUlKxxFIISP4AiwuPTHF5uCh+2CWSwwzAJiIYx0kBJsS30cp1nvhSySFAVi30jecD307jV+8Kg=="
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",

--- a/tests/Dhadgar.Mods.Tests/packages.lock.json
+++ b/tests/Dhadgar.Mods.Tests/packages.lock.json
@@ -279,15 +279,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -355,14 +346,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1021,6 +1004,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Nodes.Tests/NodesWebApplicationFactory.cs
+++ b/tests/Dhadgar.Nodes.Tests/NodesWebApplicationFactory.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -35,6 +36,18 @@ public sealed class NodesWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        // Dummy RabbitMQ credentials: RabbitMqOptions is [Required]-validated with
+        // ValidateOnStart (fail-fast since PR #127), so the test host needs non-blank
+        // values even though the bus never starts (MassTransit services are removed below).
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RabbitMq:Username"] = "test-rabbit-user",
+                ["RabbitMq:Password"] = "test-rabbit-password"
+            });
+        });
 
         builder.ConfigureServices(services =>
         {

--- a/tests/Dhadgar.Nodes.Tests/RabbitMqOptionsValidationTests.cs
+++ b/tests/Dhadgar.Nodes.Tests/RabbitMqOptionsValidationTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Dhadgar.Nodes.Tests;
+
+/// <summary>
+/// Verifies that <see cref="RabbitMqOptions"/> rejects missing, empty, and whitespace-only
+/// credentials through the same wiring Nodes uses at startup
+/// (<c>AddOptions().Bind().ValidateDataAnnotations().ValidateOnStart()</c> in Program.cs).
+/// The PR-cleared appsettings values are "" (not null), so [Required] must reject blanks
+/// for the fail-fast to be real.
+/// </summary>
+public class RabbitMqOptionsValidationTests
+{
+    private static ServiceProvider BuildProvider(string? host, string? username, string? password)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["RabbitMq:Host"] = host,
+            ["RabbitMq:Username"] = username,
+            ["RabbitMq:Password"] = password
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Mirror the wiring in src/Dhadgar.Nodes/Program.cs
+        services.AddOptions<RabbitMqOptions>()
+            .Bind(config.GetSection(RabbitMqOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RabbitMqOptions_MissingOrBlankUsername_FailsValidation(string? username)
+    {
+        using var provider = BuildProvider("localhost", username, "valid-password");
+
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<RabbitMqOptions>>().Value);
+
+        Assert.Contains("Username", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RabbitMqOptions_MissingOrBlankPassword_FailsValidation(string? password)
+    {
+        using var provider = BuildProvider("localhost", "valid-user", password);
+
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<RabbitMqOptions>>().Value);
+
+        Assert.Contains("Password", ex.Message);
+    }
+
+    [Fact]
+    public void RabbitMqOptions_BlankCredentials_FailStartupValidation()
+    {
+        // ValidateOnStart is what turns validation failures into host-startup failures;
+        // IStartupValidator is the hook the host invokes when it starts.
+        using var provider = BuildProvider("localhost", "", "");
+
+        var validator = provider.GetRequiredService<IStartupValidator>();
+
+        Assert.Throws<OptionsValidationException>(() => validator.Validate());
+    }
+
+    [Fact]
+    public void RabbitMqOptions_ValidCredentials_PassValidation()
+    {
+        using var provider = BuildProvider("rabbit.internal", "valid-user", "valid-password");
+
+        var options = provider.GetRequiredService<IOptions<RabbitMqOptions>>().Value;
+
+        Assert.Equal("rabbit.internal", options.Host);
+        Assert.Equal("valid-user", options.Username);
+        Assert.Equal("valid-password", options.Password);
+        Assert.Equal("/", options.VirtualHost);
+    }
+
+    [Fact]
+    public void RabbitMqOptions_ValidCredentials_PassStartupValidation()
+    {
+        using var provider = BuildProvider("localhost", "valid-user", "valid-password");
+
+        var validator = provider.GetRequiredService<IStartupValidator>();
+
+        validator.Validate();
+    }
+}

--- a/tests/Dhadgar.Nodes.Tests/packages.lock.json
+++ b/tests/Dhadgar.Nodes.Tests/packages.lock.json
@@ -309,15 +309,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -385,14 +376,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1049,6 +1032,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Notifications.Tests/NotificationsWebApplicationFactory.cs
+++ b/tests/Dhadgar.Notifications.Tests/NotificationsWebApplicationFactory.cs
@@ -3,6 +3,7 @@ using Dhadgar.Notifications.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -19,6 +20,18 @@ public class NotificationsWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        // Dummy RabbitMQ credentials: AddDhadgarMessaging fails fast on missing/blank
+        // credentials since PR #127; the bus itself never starts in tests (the
+        // MassTransit hosted services are removed below).
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RabbitMq:Username"] = "test-rabbit-user",
+                ["RabbitMq:Password"] = "test-rabbit-password"
+            });
+        });
 
         builder.ConfigureServices(services =>
         {

--- a/tests/Dhadgar.Notifications.Tests/packages.lock.json
+++ b/tests/Dhadgar.Notifications.Tests/packages.lock.json
@@ -314,15 +314,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -390,14 +381,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1259,6 +1242,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Secrets.Tests/Authorization/SecretsAuthorizationServiceTests.cs
+++ b/tests/Dhadgar.Secrets.Tests/Authorization/SecretsAuthorizationServiceTests.cs
@@ -35,22 +35,22 @@ public class SecretsAuthorizationServiceTests
     #region Unauthenticated Access
 
     [Fact]
-    public void Authorize_UnauthenticatedUser_ReturnsDenied()
+    public async Task Authorize_UnauthenticatedUser_ReturnsDenied()
     {
         var user = new ClaimsPrincipal(new ClaimsIdentity()); // Not authenticated
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("not authenticated", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void AuthorizeCategory_UnauthenticatedUser_ReturnsDenied()
+    public async Task AuthorizeCategory_UnauthenticatedUser_ReturnsDenied()
     {
         var user = new ClaimsPrincipal(new ClaimsIdentity());
 
-        var result = _service.AuthorizeCategory(user, "oauth", SecretAction.Read);
+        var result = await _service.AuthorizeCategoryAsync(user, "oauth", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("not authenticated", result.DenialReason, StringComparison.OrdinalIgnoreCase);
@@ -61,34 +61,34 @@ public class SecretsAuthorizationServiceTests
     #region Full Admin (secrets:*)
 
     [Fact]
-    public void Authorize_WithFullAdminPermission_Succeeds()
+    public async Task Authorize_WithFullAdminPermission_Succeeds()
     {
         var user = CreateUser("user-1", "secrets:*");
 
-        var result = _service.Authorize(user, "any-secret-name", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "any-secret-name", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.Equal("user-1", result.UserId);
     }
 
     [Fact]
-    public void Authorize_WithFullAdmin_SucceedsForAllActions()
+    public async Task Authorize_WithFullAdmin_SucceedsForAllActions()
     {
         var user = CreateUser("admin-1", "secrets:*");
 
         foreach (var action in Enum.GetValues<SecretAction>())
         {
-            var result = _service.Authorize(user, "any-secret", action);
+            var result = await _service.AuthorizeAsync(user, "any-secret", action);
             Assert.True(result.IsAuthorized, $"Expected full admin to have {action} access");
         }
     }
 
     [Fact]
-    public void AuthorizeCategory_WithFullAdmin_Succeeds()
+    public async Task AuthorizeCategory_WithFullAdmin_Succeeds()
     {
         var user = CreateUser("admin-1", "secrets:*");
 
-        var result = _service.AuthorizeCategory(user, "oauth", SecretAction.Read);
+        var result = await _service.AuthorizeCategoryAsync(user, "oauth", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
@@ -98,41 +98,41 @@ public class SecretsAuthorizationServiceTests
     #region Action Wildcard (secrets:{action}:*)
 
     [Fact]
-    public void Authorize_WithReadWildcard_SucceedsForRead()
+    public async Task Authorize_WithReadWildcard_SucceedsForRead()
     {
         var user = CreateUser("user-1", "secrets:read:*");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithReadWildcard_FailsForWrite()
+    public async Task Authorize_WithReadWildcard_FailsForWrite()
     {
         var user = CreateUser("user-1", "secrets:read:*");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Write);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Write);
 
         Assert.False(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithWriteWildcard_SucceedsForWrite()
+    public async Task Authorize_WithWriteWildcard_SucceedsForWrite()
     {
         var user = CreateUser("user-1", "secrets:write:*");
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Write);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Write);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithRotateWildcard_SucceedsForRotate()
+    public async Task Authorize_WithRotateWildcard_SucceedsForRotate()
     {
         var user = CreateUser("user-1", "secrets:rotate:*");
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Rotate);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Rotate);
 
         Assert.True(result.IsAuthorized);
     }
@@ -142,51 +142,51 @@ public class SecretsAuthorizationServiceTests
     #region Category Permissions (secrets:{action}:{category})
 
     [Fact]
-    public void Authorize_WithOAuthCategoryPermission_SucceedsForOAuthSecrets()
+    public async Task Authorize_WithOAuthCategoryPermission_SucceedsForOAuthSecrets()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithOAuthCategoryPermission_FailsForInfrastructureSecrets()
+    public async Task Authorize_WithOAuthCategoryPermission_FailsForInfrastructureSecrets()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
-        var result = _service.Authorize(user, "infra-db-password", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "infra-db-password", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithInfrastructureCategoryPermission_SucceedsForInfraSecrets()
+    public async Task Authorize_WithInfrastructureCategoryPermission_SucceedsForInfraSecrets()
     {
         var user = CreateUser("user-1", "secrets:read:infrastructure");
 
-        var result = _service.Authorize(user, "infra-db-password", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "infra-db-password", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void AuthorizeCategory_WithMatchingPermission_Succeeds()
+    public async Task AuthorizeCategory_WithMatchingPermission_Succeeds()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
-        var result = _service.AuthorizeCategory(user, "oauth", SecretAction.Read);
+        var result = await _service.AuthorizeCategoryAsync(user, "oauth", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void AuthorizeCategory_WithMismatchedPermission_Fails()
+    public async Task AuthorizeCategory_WithMismatchedPermission_Fails()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
-        var result = _service.AuthorizeCategory(user, "infrastructure", SecretAction.Read);
+        var result = await _service.AuthorizeCategoryAsync(user, "infrastructure", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
     }
@@ -196,31 +196,31 @@ public class SecretsAuthorizationServiceTests
     #region Specific Secret Permissions (secrets:{action}:{secretName})
 
     [Fact]
-    public void Authorize_WithSpecificSecretPermission_Succeeds()
+    public async Task Authorize_WithSpecificSecretPermission_Succeeds()
     {
         var user = CreateUser("user-1", "secrets:read:oauth-steam-api-key");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithSpecificSecretPermission_FailsForOtherSecrets()
+    public async Task Authorize_WithSpecificSecretPermission_FailsForOtherSecrets()
     {
         var user = CreateUser("user-1", "secrets:read:oauth-steam-api-key");
 
-        var result = _service.Authorize(user, "oauth-discord-client-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-discord-client-secret", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_WithSpecificSecretPermission_FailsForOtherActions()
+    public async Task Authorize_WithSpecificSecretPermission_FailsForOtherActions()
     {
         var user = CreateUser("user-1", "secrets:read:oauth-steam-api-key");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Write);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Write);
 
         Assert.False(result.IsAuthorized);
     }
@@ -230,7 +230,7 @@ public class SecretsAuthorizationServiceTests
     #region Break-Glass Access
 
     [Fact]
-    public void Authorize_WithBreakGlass_Succeeds()
+    public async Task Authorize_WithBreakGlass_Succeeds()
     {
         var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
         var claims = new List<Claim>
@@ -244,14 +244,14 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "sensitive-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "sensitive-secret", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.True(result.IsBreakGlass);
     }
 
     [Fact]
-    public void Authorize_WithBreakGlass_DeniedWhenExpired()
+    public async Task Authorize_WithBreakGlass_DeniedWhenExpired()
     {
         var exp = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds().ToString();
         var claims = new List<Claim>
@@ -264,14 +264,14 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("expired", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Authorize_WithBreakGlass_DeniedWhenMissingExpiration()
+    public async Task Authorize_WithBreakGlass_DeniedWhenMissingExpiration()
     {
         var claims = new List<Claim>
         {
@@ -282,14 +282,14 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("expiration", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Authorize_WithBreakGlass_DeniedWhenMissingNonce()
+    public async Task Authorize_WithBreakGlass_DeniedWhenMissingNonce()
     {
         var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
         var claims = new List<Claim>
@@ -301,14 +301,14 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("nonce", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Authorize_WithBreakGlass_DeniedOnNonceReplay()
+    public async Task Authorize_WithBreakGlass_DeniedOnNonceReplay()
     {
         var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
         var nonce = Guid.NewGuid().ToString();
@@ -323,17 +323,92 @@ public class SecretsAuthorizationServiceTests
         var user = new ClaimsPrincipal(identity);
 
         // First use succeeds
-        var result1 = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result1 = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
         Assert.True(result1.IsAuthorized);
 
         // Replay denied
-        var result2 = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result2 = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
         Assert.False(result2.IsAuthorized);
         Assert.Contains("already been used", result2.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Authorize_WithBreakGlass_DeniedWhenTtlExceedsMax()
+    public async Task Authorize_WithBreakGlass_DeniedWhenExpirationIsInvalid()
+    {
+        var claims = new List<Claim>
+        {
+            new("sub", "emergency-user"),
+            new("break_glass", "true"),
+            new("break_glass_exp", "not-a-number"),
+            new("break_glass_nonce", Guid.NewGuid().ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
+
+        Assert.False(result.IsAuthorized);
+        Assert.Contains("not a valid Unix timestamp", result.DenialReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Authorize_WithBreakGlass_DeniedWhenNonceIsEmpty_AndNonceIsNotConsumed()
+    {
+        // An empty-string nonce claim must be rejected before the tracker is consulted:
+        // "consuming" a blank nonce would permanently replay-reject all blank-nonce tokens.
+        var trackerSpy = new RecordingNonceTracker();
+        var service = new SecretsAuthorizationService(
+            OptionsFactory.Create(_options),
+            trackerSpy,
+            NullLogger<SecretsAuthorizationService>.Instance);
+
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var claims = new List<Claim>
+        {
+            new("sub", "emergency-user"),
+            new("break_glass", "true"),
+            new("break_glass_exp", exp),
+            new("break_glass_nonce", "")
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
+
+        Assert.False(result.IsAuthorized);
+        Assert.Contains("nonce", result.DenialReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(trackerSpy.ConsumedNonces);
+    }
+
+    [Fact]
+    public async Task Authorize_WithBreakGlass_DeniedWhenNonceIsWhitespace_AndNonceIsNotConsumed()
+    {
+        var trackerSpy = new RecordingNonceTracker();
+        var service = new SecretsAuthorizationService(
+            OptionsFactory.Create(_options),
+            trackerSpy,
+            NullLogger<SecretsAuthorizationService>.Instance);
+
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var claims = new List<Claim>
+        {
+            new("sub", "emergency-user"),
+            new("break_glass", "true"),
+            new("break_glass_exp", exp),
+            new("break_glass_nonce", "   ")
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
+
+        Assert.False(result.IsAuthorized);
+        Assert.Contains("nonce", result.DenialReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(trackerSpy.ConsumedNonces);
+    }
+
+    [Fact]
+    public async Task Authorize_WithBreakGlass_DeniedWhenTtlExceedsMax()
     {
         var exp = DateTimeOffset.UtcNow.AddHours(2).ToUnixTimeSeconds().ToString();
         var claims = new List<Claim>
@@ -346,14 +421,14 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "any-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "any-secret", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("exceeds maximum", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void AuthorizeCategory_WithBreakGlass_Succeeds()
+    public async Task AuthorizeCategory_WithBreakGlass_Succeeds()
     {
         var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
         var claims = new List<Claim>
@@ -366,7 +441,7 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.AuthorizeCategory(user, "oauth", SecretAction.Read);
+        var result = await _service.AuthorizeCategoryAsync(user, "oauth", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.True(result.IsBreakGlass);
@@ -377,7 +452,7 @@ public class SecretsAuthorizationServiceTests
     #region Service Account Detection
 
     [Fact]
-    public void Authorize_WithServiceAccount_DetectsServiceAccountType()
+    public async Task Authorize_WithServiceAccount_DetectsServiceAccountType()
     {
         var claims = new List<Claim>
         {
@@ -388,7 +463,7 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.True(result.IsServiceAccount);
@@ -396,11 +471,11 @@ public class SecretsAuthorizationServiceTests
     }
 
     [Fact]
-    public void Authorize_WithUserPrincipal_DetectsUserType()
+    public async Task Authorize_WithUserPrincipal_DetectsUserType()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.False(result.IsServiceAccount);
@@ -408,7 +483,7 @@ public class SecretsAuthorizationServiceTests
     }
 
     [Fact]
-    public void Authorize_WithNoPrincipalType_DefaultsToUser()
+    public async Task Authorize_WithNoPrincipalType_DefaultsToUser()
     {
         var claims = new List<Claim>
         {
@@ -418,7 +493,7 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
         Assert.False(result.IsServiceAccount);
@@ -430,32 +505,32 @@ public class SecretsAuthorizationServiceTests
     #region Category Inference from Naming Convention
 
     [Fact]
-    public void Authorize_InfersOAuthCategoryFromPrefix()
+    public async Task Authorize_InfersOAuthCategoryFromPrefix()
     {
         var user = CreateUser("user-1", "secrets:read:oauth");
 
         // Not in AllowedSecrets.OAuth list, but starts with "oauth-"
-        var result = _service.Authorize(user, "oauth-new-provider-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-new-provider-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_InfersBetterAuthCategoryFromPrefix()
+    public async Task Authorize_InfersBetterAuthCategoryFromPrefix()
     {
         var user = CreateUser("user-1", "secrets:read:betterauth");
 
-        var result = _service.Authorize(user, "betterauth-session-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "betterauth-session-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_UnknownSecret_DefaultsToCustomCategory()
+    public async Task Authorize_UnknownSecret_DefaultsToCustomCategory()
     {
         var user = CreateUser("user-1", "secrets:read:custom");
 
-        var result = _service.Authorize(user, "my-unknown-secret", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "my-unknown-secret", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
@@ -465,7 +540,7 @@ public class SecretsAuthorizationServiceTests
     #region Multiple Permissions
 
     [Fact]
-    public void Authorize_WithMultiplePermissions_SucceedsIfAnyMatches()
+    public async Task Authorize_WithMultiplePermissions_SucceedsIfAnyMatches()
     {
         var claims = new List<Claim>
         {
@@ -477,15 +552,15 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var readResult = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
-        var writeResult = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Write);
+        var readResult = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
+        var writeResult = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Write);
 
         Assert.True(readResult.IsAuthorized);
         Assert.True(writeResult.IsAuthorized);
     }
 
     [Fact]
-    public void Authorize_CaseInsensitivePermissions()
+    public async Task Authorize_CaseInsensitivePermissions()
     {
         var claims = new List<Claim>
         {
@@ -496,7 +571,7 @@ public class SecretsAuthorizationServiceTests
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var user = new ClaimsPrincipal(identity);
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.True(result.IsAuthorized);
     }
@@ -506,28 +581,74 @@ public class SecretsAuthorizationServiceTests
     #region Denial Information
 
     [Fact]
-    public void Authorize_WhenDenied_IncludesUserId()
+    public async Task Authorize_WhenDenied_IncludesUserId()
     {
         var user = CreateUser("denied-user", "unrelated:permission");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Equal("denied-user", result.UserId);
     }
 
     [Fact]
-    public void Authorize_WhenDenied_IncludesActionInReason()
+    public async Task Authorize_WhenDenied_IncludesActionInReason()
     {
         var user = CreateUser("user-1", "secrets:write:oauth");
 
-        var result = _service.Authorize(user, "oauth-steam-api-key", SecretAction.Read);
+        var result = await _service.AuthorizeAsync(user, "oauth-steam-api-key", SecretAction.Read);
 
         Assert.False(result.IsAuthorized);
         Assert.Contains("Read", result.DenialReason, StringComparison.OrdinalIgnoreCase);
     }
 
     #endregion
+
+    #region Nonce Tracker Contract
+
+    [Fact]
+    public async Task NonceTracker_NullNonce_Throws()
+    {
+        using var tracker = new InMemoryBreakGlassNonceTracker();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => tracker.TryConsumeNonceAsync(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task NonceTracker_EmptyOrWhitespaceNonce_Throws(string nonce)
+    {
+        using var tracker = new InMemoryBreakGlassNonceTracker();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => tracker.TryConsumeNonceAsync(nonce));
+    }
+
+    [Fact]
+    public async Task NonceTracker_ValidNonce_ConsumedOnceThenRejected()
+    {
+        using var tracker = new InMemoryBreakGlassNonceTracker();
+        var nonce = Guid.NewGuid().ToString();
+
+        Assert.True(await tracker.TryConsumeNonceAsync(nonce));
+        Assert.False(await tracker.TryConsumeNonceAsync(nonce));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Hand-rolled spy: records every nonce the authorization service attempts to consume.
+    /// </summary>
+    private sealed class RecordingNonceTracker : IBreakGlassNonceTracker
+    {
+        public List<string> ConsumedNonces { get; } = new();
+
+        public Task<bool> TryConsumeNonceAsync(string nonce)
+        {
+            ConsumedNonces.Add(nonce);
+            return Task.FromResult(true);
+        }
+    }
 
     private static ClaimsPrincipal CreateUser(string userId, params string[] permissions)
     {

--- a/tests/Dhadgar.Secrets.Tests/Authorization/SecretsAuthorizationServiceTests.cs
+++ b/tests/Dhadgar.Secrets.Tests/Authorization/SecretsAuthorizationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using Dhadgar.Secrets.Authorization;
 using Dhadgar.Secrets.Options;
@@ -8,10 +9,11 @@ using OptionsFactory = Microsoft.Extensions.Options.Options;
 
 namespace Dhadgar.Secrets.Tests.Authorization;
 
-public class SecretsAuthorizationServiceTests
+public sealed class SecretsAuthorizationServiceTests : IDisposable
 {
     private readonly SecretsAuthorizationService _service;
     private readonly SecretsOptions _options;
+    private readonly InMemoryBreakGlassNonceTracker _nonceTracker;
 
     public SecretsAuthorizationServiceTests()
     {
@@ -26,10 +28,17 @@ public class SecretsAuthorizationServiceTests
             }
         };
 
+        _nonceTracker = new InMemoryBreakGlassNonceTracker();
         _service = new SecretsAuthorizationService(
             OptionsFactory.Create(_options),
-            new InMemoryBreakGlassNonceTracker(),
+            _nonceTracker,
             NullLogger<SecretsAuthorizationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _nonceTracker.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     #region Unauthenticated Access
@@ -232,7 +241,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task Authorize_WithBreakGlass_Succeeds()
     {
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -253,7 +262,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task Authorize_WithBreakGlass_DeniedWhenExpired()
     {
-        var exp = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -291,7 +300,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task Authorize_WithBreakGlass_DeniedWhenMissingNonce()
     {
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -310,7 +319,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task Authorize_WithBreakGlass_DeniedOnNonceReplay()
     {
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var nonce = Guid.NewGuid().ToString();
         var claims = new List<Claim>
         {
@@ -362,7 +371,7 @@ public class SecretsAuthorizationServiceTests
             trackerSpy,
             NullLogger<SecretsAuthorizationService>.Instance);
 
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -389,7 +398,7 @@ public class SecretsAuthorizationServiceTests
             trackerSpy,
             NullLogger<SecretsAuthorizationService>.Instance);
 
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -410,7 +419,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task Authorize_WithBreakGlass_DeniedWhenTtlExceedsMax()
     {
-        var exp = DateTimeOffset.UtcNow.AddHours(2).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddHours(2).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),
@@ -430,7 +439,7 @@ public class SecretsAuthorizationServiceTests
     [Fact]
     public async Task AuthorizeCategory_WithBreakGlass_Succeeds()
     {
-        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString();
+        var exp = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
         var claims = new List<Claim>
         {
             new("sub", "emergency-user"),

--- a/tests/Dhadgar.Secrets.Tests/Security/SecretsSecurityIntegrationTests.cs
+++ b/tests/Dhadgar.Secrets.Tests/Security/SecretsSecurityIntegrationTests.cs
@@ -442,7 +442,11 @@ public sealed class SecureSecretsWebApplicationFactory : WebApplicationFactory<P
             new("sub", userId),
             new("principal_type", "user"),
             new("break_glass", "true"),
-            new("break_glass_reason", reason)
+            new("break_glass_reason", reason),
+            // Break-glass hardening (PR #127): tokens must carry a bounded expiration
+            // (max 1-hour TTL) and a single-use nonce, or authorization is denied.
+            new("break_glass_exp", DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            new("break_glass_nonce", Guid.NewGuid().ToString())
         };
 
         return CreateClientWithToken(claims);

--- a/tests/Dhadgar.Secrets.Tests/packages.lock.json
+++ b/tests/Dhadgar.Secrets.Tests/packages.lock.json
@@ -125,15 +125,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -201,14 +192,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -805,6 +788,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Servers.Tests/packages.lock.json
+++ b/tests/Dhadgar.Servers.Tests/packages.lock.json
@@ -291,15 +291,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -367,14 +358,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1027,6 +1010,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.ServiceDefaults.Tests/packages.lock.json
+++ b/tests/Dhadgar.ServiceDefaults.Tests/packages.lock.json
@@ -182,15 +182,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -258,14 +249,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -682,6 +665,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {

--- a/tests/Dhadgar.Shared.Tests/packages.lock.json
+++ b/tests/Dhadgar.Shared.Tests/packages.lock.json
@@ -78,14 +78,6 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
-        }
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -203,6 +195,15 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/tests/Dhadgar.Tasks.Tests/packages.lock.json
+++ b/tests/Dhadgar.Tasks.Tests/packages.lock.json
@@ -279,15 +279,6 @@
           "Microsoft.Extensions.ObjectPool": "10.0.2"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Primitives": "10.0.2"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.2",
@@ -355,14 +346,6 @@
           "Microsoft.Extensions.Configuration.Json": "10.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -1021,6 +1004,25 @@
         "dependencies": {
           "Microsoft.Extensions.Compliance.Abstractions": "10.2.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.2",
+        "contentHash": "J/Zmp6fY93JbaiZ11ckWvcyxMPjD6XVwIHQXBjryTBgn7O6O20HYg9uVLFcZlNfgH78MnreE/7EH+hjfzn7VyA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2"
         }
       },
       "Microsoft.Extensions.Hosting": {


### PR DESCRIPTION
Supersedes #127.

## Summary

This PR carries over the entire P0 security hardening from #127 (its single commit `4160d8c`, rebased cleanly onto current `main` as the first commit of this branch) and repairs the one unresolved critical review finding on top.

### Carried over from #127

- **#108**: hardcoded `dhadgar`/`dhadgar` Postgres and RabbitMQ credentials cleared from all 11 service `appsettings.json` files; fallback defaults removed from ServiceDefaults, Messaging, and Nodes `RabbitMqOptions`
- **#109**: `dev-client`/`dev-secret` fallbacks removed from OpenIddict DevClient seeding (warn-and-skip when unconfigured)
- **#110**: break-glass access now enforces expiration (max 1-hour TTL via `break_glass_exp`) and single-use nonces (`break_glass_nonce`) with replay rejection
- **#111**: deterministic service-account secrets replaced with 256-bit `RandomNumberGenerator` values; WIF credential fallbacks removed

### New on top (second commit)

- **Real fail-fast**: the cleared appsettings values are `""` (not null), so #127's `?? throw` guards never fired. Every `?? throw` the PR introduced is replaced with `string.IsNullOrWhiteSpace` checks throwing `InvalidOperationException` naming the exact missing config key (`MessagingExtensions.cs`, `ServiceDefaultsExtensions.cs`, `WifCredentialProvider.cs`). Nodes' `RabbitMqOptions` needs no change: `[Required]` + `ValidateDataAnnotations().ValidateOnStart()` already rejects blank values (now covered by tests).
- **Fixture credential updates**: `NodesWebApplicationFactory`, `DiscordWebApplicationFactory`, and `NotificationsWebApplicationFactory` provide dummy RabbitMQ credentials via in-memory configuration; `SecretsSecurityIntegrationTests` break-glass clients now carry the required `break_glass_exp`/`break_glass_nonce` claims.
- **New unit tests**: `tests/Dhadgar.Messaging.Tests/MessagingExtensionsCredentialValidationTests.cs` and `tests/Dhadgar.Nodes.Tests/RabbitMqOptionsValidationTests.cs` assert the throw for null, `""`, and whitespace username/password and non-throw for valid values.
- **XML doc corrections**: `MessagingExtensions.cs` no longer advertises `dhadgar` defaults; the required keys and startup exception are documented.

### Review-sweep fixes (third commit, P0.3 of #129)

All 17 CodeRabbit findings from #127 are dispositioned in [this comment](https://github.com/SandboxServers/MeridianConsole/pull/139#issuecomment-5084543899). Code changes:

- **Service-account seeding no longer bricks `client_credentials` accounts**: when `OpenIddict:ServiceAccounts:{key}:ClientSecret` is unconfigured, seeding warns and skips (matching the DevClient pattern) instead of storing an unrecoverable random hashed secret; a random placeholder remains only for WIF-only accounts (`scopes == ["wif"]`). Generated secret bytes are zeroed with `CryptographicOperations.ZeroMemory`.
- **Secrets authorization is async end-to-end**: `ISecretsAuthorizationService.AuthorizeAsync`/`AuthorizeCategoryAsync` replace the sync API, eliminating the `.GetAwaiter().GetResult()` sync-over-async on the break-glass nonce path; the TTL/expiry checks now evaluate against a single captured `UtcNow`.
- **Nonce tracker hardening**: `IBreakGlassNonceTracker` documents the non-blank nonce contract and the single-instance limitation; `InMemoryBreakGlassNonceTracker` guards with `ArgumentException.ThrowIfNullOrWhiteSpace`, derives its 2h retention from the new `BreakGlassPolicy.MaxTtl` constant (no more implicit coupling), and exception-proofs the cleanup timer callback.
- **WIF provider**: misleading `"(default)"` log label fixed; the `ClientAssertionCredential` exception-vs-`Result<T>` constraint documented.
- **Identity → Secrets URL**: `SecretsService.Url` corrected from `5000` (Gateway) to the direct Secrets port `5110`, matching compose deployment wiring and Discord's config.

## Test plan

- Full solution `dotnet test` (P0.2, second commit): 1,648 passed across 25 assemblies, 0 failures apart from the Docker-dependent AppHost orchestration tests (6 of 12 fail on Docker-equipped machines because AppHost injects no `RabbitMq__*` credentials — recorded on #134/DV-6) and the known environment-specific `DirectoryAclManagerTests` failure that reproduces identically on `main`.
- P0.3 (third commit): full solution build clean; affected projects re-run — `Dhadgar.Secrets.Tests` 154 passed (was 147; 7 new authorization/nonce-contract tests), `Dhadgar.Identity.Tests` 211 passed.

Closes #108
Closes #109
Closes #110
Closes #111

Follow-up issues for the unmet acceptance criteria of #108-#111 are filed in a later chunk (P0.4 of #129).

Part of #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGdu91QcJ9qCxa1a2qz6gb
