### PR TITLE
fix(compose): require RabbitMQ credentials via environment (P0.4)

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -2,8 +2,10 @@ POSTGRES_USER=dhadgar
 POSTGRES_PASSWORD=dhadgar
 POSTGRES_DB=dhadgar_platform
 
-RABBITMQ_DEFAULT_USER=dhadgar
-RABBITMQ_DEFAULT_PASS=dhadgar
+# Used by both the RabbitMQ broker (RABBITMQ_DEFAULT_USER/PASS) and the
+# service clients (RabbitMq__Username/RabbitMq__Password) so they stay in sync.
+RABBITMQ_USERNAME=dhadgar
+RABBITMQ_PASSWORD=dhadgar
 
 REDIS_PASSWORD=dhadgar
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -112,8 +112,8 @@ Override defaults by creating a `.env` file in this directory:
 POSTGRES_USER=myuser
 POSTGRES_PASSWORD=mypassword
 POSTGRES_DB=mydb
-RABBITMQ_DEFAULT_USER=myuser
-RABBITMQ_DEFAULT_PASS=mypassword
+RABBITMQ_USERNAME=myuser
+RABBITMQ_PASSWORD=mypassword
 REDIS_PASSWORD=mypassword
 GRAFANA_ADMIN_USER=myadmin
 GRAFANA_ADMIN_PASSWORD=myadminpass

--- a/deploy/compose/docker-compose.dev.yml
+++ b/deploy/compose/docker-compose.dev.yml
@@ -20,8 +20,10 @@ services:
   rabbitmq:
     image: rabbitmq:3-management
     environment:
-      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-dhadgar}
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-dhadgar}
+      # Wired to the same variables the service clients use (RabbitMq__Username/RabbitMq__Password
+      # in docker-compose.services.yml) so the broker and its clients cannot drift apart.
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME:-dhadgar}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:?RABBITMQ_PASSWORD must be set}
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/deploy/compose/docker-compose.services.acr.yml
+++ b/deploy/compose/docker-compose.services.acr.yml
@@ -14,10 +14,10 @@ x-service-image: &service-image
 
 x-service-env: &service-env
   ASPNETCORE_ENVIRONMENT: Development
-  ConnectionStrings__Postgres: Host=postgres;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=dhadgar
+  ConnectionStrings__Postgres: Host=postgres;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
   ConnectionStrings__RabbitMqHost: rabbitmq
-  RabbitMq__Username: dhadgar
-  RabbitMq__Password: dhadgar
+  RabbitMq__Username: ${RABBITMQ_USERNAME:-dhadgar}
+  RabbitMq__Password: ${RABBITMQ_PASSWORD:?RABBITMQ_PASSWORD must be set}
 
 x-service-depends: &service-depends
   postgres:

--- a/deploy/compose/docker-compose.services.yml
+++ b/deploy/compose/docker-compose.services.yml
@@ -2,8 +2,8 @@ x-service-env: &service-env
   ASPNETCORE_ENVIRONMENT: Development
   ConnectionStrings__Postgres: Host=postgres;Port=5432;Database=dhadgar_platform;Username=dhadgar;Password=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
   ConnectionStrings__RabbitMqHost: rabbitmq
-  RabbitMq__Username: dhadgar
-  RabbitMq__Password: dhadgar
+  RabbitMq__Username: ${RABBITMQ_USERNAME:-dhadgar}
+  RabbitMq__Password: ${RABBITMQ_PASSWORD:?RABBITMQ_PASSWORD must be set}
 
 x-service-depends: &service-depends
   postgres:


### PR DESCRIPTION
## Summary

Removes the last hardcoded-credential remnant of #108 in deploy artifacts (issue #129, chunk P0.4). PR #139 (which supersedes #127) covers the .NET-side credential fail-fast; the compose files still shipped `RabbitMq__Username: dhadgar` / `RabbitMq__Password: dhadgar` in their top-level shared env blocks.

Changes:

- `deploy/compose/docker-compose.services.yml` — shared env block now uses `RabbitMq__Username: ${RABBITMQ_USERNAME:-dhadgar}` and `RabbitMq__Password: ${RABBITMQ_PASSWORD:?RABBITMQ_PASSWORD must be set}`, the same pattern the Postgres connection string there already uses.
- `deploy/compose/docker-compose.services.acr.yml` — same fix for the identical hardcoded block; additionally, its `ConnectionStrings__Postgres` still hardcoded `Password=dhadgar` (same remnant class, same block), now `${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}` to match the non-ACR file.
- `deploy/compose/docker-compose.dev.yml` — the RabbitMQ broker previously read `${RABBITMQ_DEFAULT_USER:-dhadgar}` / `${RABBITMQ_DEFAULT_PASS:-dhadgar}`, i.e. different variables than the clients; setting only `RABBITMQ_PASSWORD` would have desynced broker and clients. Both are now wired to the same `RABBITMQ_USERNAME`/`RABBITMQ_PASSWORD` variables.
- `deploy/compose/.env.example` — replaced `RABBITMQ_DEFAULT_USER/PASS` with `RABBITMQ_USERNAME`/`RABBITMQ_PASSWORD` (this file already exists, so no gap to defer; a fuller required-env-var documentation pass is Phase 4 #133 / the #108-remnant follow-up issue).
- `deploy/compose/README.md` — example `.env` snippet updated to the new variable names.

Note: `docker-compose.services.acr.yml` cannot be validated standalone — its `depends_on` anchors reference the `postgres`/`rabbitmq` services defined in `docker-compose.dev.yml`, matching the usage in its own header. Validation below uses the file pairs as documented.

## Validation transcript

With `POSTGRES_PASSWORD` and `RABBITMQ_PASSWORD` set (`testpg`/`testrmq`):

```text
$ docker compose -f docker-compose.dev.yml -f docker-compose.services.yml config   # exit 0
      RABBITMQ_DEFAULT_PASS: testrmq
      RABBITMQ_DEFAULT_USER: dhadgar
      RabbitMq__Password: testrmq
      RabbitMq__Username: dhadgar

$ docker compose -f docker-compose.dev.yml -f docker-compose.services.acr.yml config   # exit 0
      ConnectionStrings__Postgres: Host=postgres;...;Username=dhadgar;Password=testpg
      RABBITMQ_DEFAULT_PASS: testrmq
      RabbitMq__Password: testrmq
```

Without `RABBITMQ_PASSWORD` (both file pairs, exit 1):

```text
error while interpolating services.rabbitmq.environment.RABBITMQ_DEFAULT_PASS:
required variable RABBITMQ_PASSWORD is missing a value: RABBITMQ_PASSWORD must be set
```

Part of #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGdu91QcJ9qCxa1a2qz6gb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local environment configuration guidance with the new RabbitMQ username and password variable names.
  * Added notes clarifying that these credentials must remain consistent across broker and service settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->